### PR TITLE
Add Next.js skeleton and home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # kp-personal-website
 
-Personal website of Kavi Pather. This repository contains a simple "Hello World" page used for GitHub Pages.
+This site uses a minimal Next.js setup styled with Tailwind CSS.
+It follows the design tokens in `DESIGN_GUIDE.md`.
 
-See [DESIGN_GUIDE.md](DESIGN_GUIDE.md) for layout and styling guidance when updating the site.
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+Blog posts live in the `blog/` folder as markdown files.

--- a/blog/2023-10-25.md
+++ b/blog/2023-10-25.md
@@ -1,0 +1,5 @@
+---
+title: "Conference Talk"
+date: 2023-10-25
+---
+Spoke at the annual analytics summit about AI ethics.

--- a/blog/2023-11-04.md
+++ b/blog/2023-11-04.md
@@ -1,0 +1,5 @@
+---
+title: "New AI Initiative"
+date: 2023-11-04
+---
+Started an exciting new project exploring agentic AI systems.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "kp-personal-website",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.21",
+    "tailwindcss": "3.3.5",
+    "typescript": "5.2.2"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app'
+import '../styles/globals.css'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,92 @@
+import fs from 'fs'
+import path from 'path'
+import Head from 'next/head'
+
+interface Post {
+  date: string
+  title: string
+}
+
+export async function getStaticProps() {
+  const dir = path.join(process.cwd(), 'blog')
+  const posts: Post[] = fs.readdirSync(dir).map((name) => {
+    const content = fs.readFileSync(path.join(dir, name), 'utf8')
+    const dateMatch = content.match(/date:\s*(.*)/)
+    const titleMatch = content.match(/title:\s*"(.*)"/)
+    return {
+      date: dateMatch ? dateMatch[1] : '',
+      title: titleMatch ? titleMatch[1] : name.replace('.md', '')
+    }
+  })
+  posts.sort((a, b) => (a.date < b.date ? 1 : -1))
+  return { props: { posts } }
+}
+
+export default function Home({ posts }: { posts: Post[] }) {
+  return (
+    <>
+      <Head>
+        <title>Kavi Pather</title>
+      </Head>
+      <header className="flex justify-between items-center py-lg max-prose">
+        <h1 className="text-3xl font-bold leading-tight">
+          <span className="block">Kavi</span>
+          <span className="block">Pather</span>
+        </h1>
+        <nav className="flex items-center space-x-4">
+          <div className="flex space-x-2 mr-4">
+            <a href="https://www.linkedin.com/in/kavipather/" aria-label="LinkedIn">🔗</a>
+            <a href="https://x.com/kavi_pather" aria-label="X">✖️</a>
+            <a href="https://youtube.com/channel/UChMl5Ua89sbb9ie10bVbHTQ" aria-label="YouTube">▶️</a>
+          </div>
+          <a href="/blog" className="hover:text-accent">Blog</a>
+          <a href="/media" className="hover:text-accent">Media Links</a>
+          <a href="/cv" className="hover:text-accent">CV</a>
+        </nav>
+      </header>
+
+      <img src="/images/hero.jpg" alt="Cityscape" className="w-full h-auto" />
+
+      <section className="max-prose">
+        <p>
+          I'm an <strong>AI and analytics leader</strong> working at the intersection of
+          technology, business, and human potential. With a foundation in
+          consulting and a passion for systems thinking, I help organizations not
+          just adopt AI—but integrate it meaningfully to reimagine how they
+          operate, compete, and serve. My work spans agentic AI, enterprise
+          transformation, and real-world deployment across emerging markets, with
+          a particular focus on financial services. I’m driven by a belief that
+          the right combination of design, data, and judgement can unlock not
+          only performance—but purpose.
+        </p>
+      </section>
+
+      <section className="max-prose">
+        <h2 className="text-xl font-semibold mb-4">Updates</h2>
+        <ul>
+          {posts.map((post) => (
+            <li key={post.date} className="flex justify-between border-b py-2">
+              <span className="text-sm text-right w-32 font-mono">{post.date}</span>
+              <span className="flex-1 ml-4">{post.title}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-2">
+          <a href="/blog" className="hover:text-accent">More…</a>
+        </div>
+      </section>
+
+      <section className="max-prose">
+        <h2 className="text-xl font-semibold mb-4">Contact</h2>
+        <p><strong>Kavi Pather</strong></p>
+        <p><a href="mailto:someone@example.com">someone@example.com</a></p>
+        <p><strong>Affiliation:</strong> EY</p>
+        <p>Johannesburg</p>
+      </section>
+
+      <footer className="text-center text-sm text-gray-500 py-lg">
+        © Kavi Pather
+      </footer>
+    </>
+  )
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/public/images/hero.jpg
+++ b/public/images/hero.jpg
@@ -1,0 +1,1 @@
+placeholder hero image

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,17 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap');
+
+body {
+  @apply font-sans bg-white text-black;
+}
+
+section {
+  @apply py-xl;
+}
+
+.max-prose {
+  @apply max-w-prose mx-auto;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,25 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        accent: '#10A37F'
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif']
+      },
+      spacing: {
+        xl: '4rem',
+        lg: '2rem'
+      },
+      maxWidth: {
+        prose: '960px'
+      }
+    }
+  },
+  plugins: []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js project structure with Tailwind
- implement homepage layout with header, hero image, intro, updates, contact, footer
- add example blog posts in markdown
- document project setup in README

## Testing
- `npm test` *(fails: Missing script)*