### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy Next.js to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build and export
+        run: |
+          npm run build
+          npm run export
+          touch out/.nojekyll
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,9 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
-module.exports = nextConfig
+const nextConfig = {
+  output: 'export',
+  basePath: '/kp-personal-website',
+  assetPrefix: '/kp-personal-website',
+};
+
+module.exports = nextConfig;
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "export": "next export"
   },
   "dependencies": {
     "next": "13.5.6",
@@ -19,3 +20,4 @@
     "typescript": "5.2.2"
   }
 }
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy static site to GitHub Pages
- configure Next.js for static export with repo base path
- add `export` script to package.json

## Testing
- `npm install` *(fails: unknown env config, network not available)*
- `npm run build` *(fails: next not found due to failed install)*