### PR TITLE
Switch to new static export config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Build and export
+      - name: Build
         run: |
           npm run build
-          npm run export
           touch out/.nojekyll
 
       - name: Deploy to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ npm run dev
 
 Blog posts live in the `blog/` folder as markdown files.
 
-## Build & Export
+## Build
 
 Generate the static site for deployment:
 
 ```bash
 npm run build
-npm run export
 ```
 
-The exported files are written to the `out/` directory.
+The static files are written to the `out/` directory.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
-    "export": "next export"
+    "start": "next start"
   },
   "dependencies": {
     "next": "^14.2.29",


### PR DESCRIPTION
## Summary
- remove obsolete `npm run export` usage
- update README and GitHub Actions workflow for Next.js 14 static export

## Testing
- `npm run build`