### PR TITLE
Enable gh-pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,8 @@ jobs:
           npm run build
           touch out/.nojekyll
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
+      - name: Deploy
+        run: npm run deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ npm run build
 ```
 
 The static files are written to the `out/` directory.
+
+## Deploy
+
+Push the contents of `out/` to the `gh-pages` branch with:
+
+```bash
+npm run deploy
+```
+
+GitHub Pages should be configured to serve from that branch.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "deploy": "npm run build && gh-pages -d out",
     "start": "next start"
   },
   "dependencies": {
@@ -19,6 +20,7 @@
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.3.5",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "gh-pages": "^6.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- add `deploy` script using `gh-pages`
- update workflow to run the new script
- document how to deploy via `gh-pages` branch

## Testing
- `npm run build`
