### PR TITLE
Fix Git identity for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,11 @@ jobs:
           npm run build
           touch out/.nojekyll
 
+      - name: Set Git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Deploy
         run: npm run deploy
         env:


### PR DESCRIPTION
## Notes
- No additional notes.

## Summary
- configure git user.name and user.email in the deployment workflow before running `npm run deploy`
- `npm run build` ran successfully
