### PR TITLE
Change Next build output dir to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ web_modules/
 # Next.js build output
 .next
 out
+docs
 
 # Nuxt.js build / generate output
 .nuxt

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+  distDir: 'docs',
   basePath: '/kp-personal-website',
   assetPrefix: '/kp-personal-website',
 };


### PR DESCRIPTION
## Notes
- n/a

## Summary
- configure Next.js to build into `docs`
- ignore the `docs` folder in git

Build output:
```
$ npm run build
```
(see logs for successful compilation)
