### PR TITLE
Fix homepage title

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,7 +26,7 @@ export default function Home({ posts }: { posts: Post[] }) {
   return (
     <>
       <Head>
-        <title>Kavi Pather.</title>
+        <title>Kavi Pather</title>
       </Head>
       <header className="flex justify-between items-center py-lg max-prose">
         <h1 className="text-3xl font-bold leading-tight">


### PR DESCRIPTION
## Notes
- n/a

## Summary
- remove trailing period from the homepage `<title>` tag
- `npm run build` completed successfully

